### PR TITLE
Moved Home to Icon as Spurious + Slack Icon as Connect without 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # iNOG main website
 
 Repository for homepage of [Ireland's Network Operator Group](https://inog.net).
+
+Note: We're working on relative/absolute link issues so for the moment please
+
+`sudo python -m SimpleHTTPServer 80` to serve local files...

--- a/pub/index.html
+++ b/pub/index.html
@@ -41,14 +41,13 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <img src="img/inog.svg" class="img-responsive navbar-brand">
+          <a href="https://inog.net"><img src="img/inog.svg" class="img-responsive navbar-brand"></a>
         </div>
         <div class="navbar-collapse collapse" id="navbar-main">
           <ul class="nav navbar-nav navbar-right">
-            <li><a class="btn btn-link" href="/"><strong>Home</strong></a></li>
             <!-- <li><a class="btn btn-link" href="people.html">People</a></li> -->
             <li><a class="btn btn-link" data-toggle="modal" data-target="#CofCmodal">Code of Conduct</a></li>
-            <li><a class="btn btn-link" href="https://inog.net/talk"><div class="text-success">Propose a Talk!</div></a></li>
+            <li><a class="btn btn-link" href="https://inog.net/talk"><div class="btn btn-sm btn-success">Share Your Experience</div></a></li>
             <li><a class="btn btn-link" href="http://slack.inog.net:3000/" target="_blank">Connect</a></li>
             <li><a class="btn btn-link" href="https://www.youtube.com/channel/UCBl3zIF_JJZd1iOjvU1ItZw?sub_confirmation=1" target="_blank">Videos</a></li>
             <li><a class="btn btn-link" href="https://twitter.com/inognet" target="_blank"><i class="fa fa-twitter"></i></a></li>

--- a/pub/index.html
+++ b/pub/index.html
@@ -46,6 +46,7 @@
         <div class="navbar-collapse collapse" id="navbar-main">
           <ul class="nav navbar-nav navbar-right">
             <!-- <li><a class="btn btn-link" href="people.html">People</a></li> -->
+            <li><a class="btn btn-link" href="/"><i class="fa fa-home"></i></a></li>
             <li><a class="btn btn-link" data-toggle="modal" data-target="#CofCmodal">Code of Conduct</a></li>
             <li><a class="btn btn-link" href="/talk"><div class="">Speak at iNOG</div></a></li>
             <li><a class="btn btn-link" href="https://www.youtube.com/channel/UCBl3zIF_JJZd1iOjvU1ItZw?sub_confirmation=1" target="_blank">Videos</a></li>
@@ -69,7 +70,7 @@
           <p>Thu 08 Jun 2017
           <br>6:00 PM to 9:30 PM
           <br>Amazon, Dublin</p>
-          <p><a href="https://www.meetup.com/Irish-Network-Operators-Group/events/228394351/" target="_blank" class="btn btn-success"><strong>RSVP on Meetup!</strong></a></p>
+          <p><a href="https://www.meetup.com/Irish-Network-Operators-Group/events/228394351/" target="_blank" class="btn btn-warning"><strong>RSVP on Meetup!</strong></a></p>
           <p><small class="futuremeets"></small></p>
          </div>
         </div>

--- a/pub/index.html
+++ b/pub/index.html
@@ -41,15 +41,15 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a href="https://inog.net"><img src="img/inog.svg" class="img-responsive navbar-brand"></a>
+          <a href="/"><img src="img/inog.svg" class="img-responsive navbar-brand"></a>
         </div>
         <div class="navbar-collapse collapse" id="navbar-main">
           <ul class="nav navbar-nav navbar-right">
             <!-- <li><a class="btn btn-link" href="people.html">People</a></li> -->
             <li><a class="btn btn-link" data-toggle="modal" data-target="#CofCmodal">Code of Conduct</a></li>
-            <li><a class="btn btn-link" href="https://inog.net/talk"><div class="btn btn-sm btn-success">Share Your Experience</div></a></li>
-            <li><a class="btn btn-link" href="http://slack.inog.net:3000/" target="_blank">Connect</a></li>
+            <li><a class="btn btn-link" href="/talk"><div class="">Speak at iNOG</div></a></li>
             <li><a class="btn btn-link" href="https://www.youtube.com/channel/UCBl3zIF_JJZd1iOjvU1ItZw?sub_confirmation=1" target="_blank">Videos</a></li>
+            <li><a class="btn btn-link" href="http://slack.inog.net:3000/" target="_blank"><i class="fa fa-slack"></i></a></li>
             <li><a class="btn btn-link" href="https://twitter.com/inognet" target="_blank"><i class="fa fa-twitter"></i></a></li>
           </ul>
         </div>
@@ -69,7 +69,7 @@
           <p>Thu 08 Jun 2017
           <br>6:00 PM to 9:30 PM
           <br>Amazon, Dublin</p>
-          <p><a href="https://www.meetup.com/Irish-Network-Operators-Group/events/228394351/" target="_blank" class="btn btn-warning"><strong>RSVP on Meetup!</strong></a></p>
+          <p><a href="https://www.meetup.com/Irish-Network-Operators-Group/events/228394351/" target="_blank" class="btn btn-success"><strong>RSVP on Meetup!</strong></a></p>
           <p><small class="futuremeets"></small></p>
          </div>
         </div>

--- a/pub/pc.html
+++ b/pub/pc.html
@@ -46,6 +46,7 @@
         <div class="navbar-collapse collapse" id="navbar-main">
           <ul class="nav navbar-nav navbar-right">
             <!-- <li><a class="btn btn-link" href="people.html">People</a></li> -->
+            <li><a class="btn btn-link" href="/"><i class="fa fa-home"></i></a></li>
             <li><a class="btn btn-link" data-toggle="modal" data-target="#CofCmodal">Code of Conduct</a></li>
             <li><a class="btn btn-link" href="http://slack.inog.net:3000/" target="_blank">Connect</a></li>
             <li><a class="btn btn-link" href="https://twitter.com/inognet" target="_blank"><i class="fa fa-twitter"></i></a></li>

--- a/pub/pc.html
+++ b/pub/pc.html
@@ -41,7 +41,7 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a href="https://inog.net"><img src="img/inog.svg" class="img-responsive navbar-brand"></a>
+          <a href="/"><img src="img/inog.svg" class="img-responsive navbar-brand"></a>
         </div>
         <div class="navbar-collapse collapse" id="navbar-main">
           <ul class="nav navbar-nav navbar-right">

--- a/pub/pc.html
+++ b/pub/pc.html
@@ -41,11 +41,10 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <img src="img/inog.svg" class="img-responsive navbar-brand">
+          <a href="https://inog.net"><img src="img/inog.svg" class="img-responsive navbar-brand"></a>
         </div>
         <div class="navbar-collapse collapse" id="navbar-main">
           <ul class="nav navbar-nav navbar-right">
-            <li><a class="btn btn-link" href="/">Home</a></li>
             <!-- <li><a class="btn btn-link" href="people.html">People</a></li> -->
             <li><a class="btn btn-link" data-toggle="modal" data-target="#CofCmodal">Code of Conduct</a></li>
             <li><a class="btn btn-link" href="http://slack.inog.net:3000/" target="_blank">Connect</a></li>

--- a/pub/talk/index.html
+++ b/pub/talk/index.html
@@ -46,6 +46,7 @@
         <div class="navbar-collapse collapse" id="navbar-main">
           <ul class="nav navbar-nav navbar-right">
             <!-- <li><a class="btn btn-link" href="people.html">People</a></li> -->
+            <li><a class="btn btn-link" href="/"><i class="fa fa-home"></i></a></li>
             <li><a class="btn btn-link" data-toggle="modal" data-target="#CofCmodal">Code of Conduct</a></li>
             <li><a class="btn btn-link" href="https://inog.net/talk"><strong class="text-success">Propose a Talk!</strong></a></li>
             <li><a class="btn btn-link" href="https://www.youtube.com/channel/UCBl3zIF_JJZd1iOjvU1ItZw?sub_confirmation=1" target="_blank">Videos</a></li>

--- a/pub/talk/index.html
+++ b/pub/talk/index.html
@@ -41,11 +41,10 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <img src="../img/inog.svg" class="img-responsive navbar-brand">
+          <a href="https://inog.net"><img src="../img/inog.svg" class="img-responsive navbar-brand"></a>
         </div>
         <div class="navbar-collapse collapse" id="navbar-main">
           <ul class="nav navbar-nav navbar-right">
-            <li><a class="btn btn-link" href="/">Home</a></li>
             <!-- <li><a class="btn btn-link" href="people.html">People</a></li> -->
             <li><a class="btn btn-link" data-toggle="modal" data-target="#CofCmodal">Code of Conduct</a></li>
             <li><a class="btn btn-link" href="https://inog.net/talk"><strong class="text-success">Propose a Talk!</strong></a></li>

--- a/pub/talk/index.html
+++ b/pub/talk/index.html
@@ -41,15 +41,15 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a href="https://inog.net"><img src="../img/inog.svg" class="img-responsive navbar-brand"></a>
+          <a href="/"><img src="../img/inog.svg" class="img-responsive navbar-brand"></a>
         </div>
         <div class="navbar-collapse collapse" id="navbar-main">
           <ul class="nav navbar-nav navbar-right">
             <!-- <li><a class="btn btn-link" href="people.html">People</a></li> -->
             <li><a class="btn btn-link" data-toggle="modal" data-target="#CofCmodal">Code of Conduct</a></li>
             <li><a class="btn btn-link" href="https://inog.net/talk"><strong class="text-success">Propose a Talk!</strong></a></li>
-            <li><a class="btn btn-link" href="http://slack.inog.net:3000/" target="_blank">Connect</a></li>
             <li><a class="btn btn-link" href="https://www.youtube.com/channel/UCBl3zIF_JJZd1iOjvU1ItZw?sub_confirmation=1" target="_blank">Videos</a></li>
+						<li><a class="btn btn-link" href="http://slack.inog.net:3000/" target="_blank"><i class="fa fa-slack"></i></a></li>
             <li><a class="btn btn-link" href="https://twitter.com/inognet" target="_blank"><i class="fa fa-twitter"></i></a></li>
           </ul>
         </div>


### PR DESCRIPTION
Moved Home to Icon as Spurious additional Home link not needed.
Slack Icon as Connect without context might as well be Slack for now otherwise it's confusing either way.
Green is go and do for RSVP to next iNOG. Orange is indeed 'Warning' and shouldn't be used for links or Calls to Action. 